### PR TITLE
Account for tag prefix in `git describe`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-tag-action",
-  "version": "4.5.0",
+  "version": "4.7.1",
   "private": true,
   "description": "A GitHub Action to automatically bump and tag master, on merge, with the latest SemVer formatted version.",
   "main": "lib/main.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ async function run() {
       const previousTagSha = (
         await exec(`git rev-list --tags=${tagPrefix}* --topo-order --max-count=1`)
       ).stdout.trim();
-      tag = (await exec(`git describe --tags ${previousTagSha}`)).stdout.trim();
+      tag = (await exec(`git describe --tags --match="${tagPrefix}*" ${previousTagSha}`)).stdout.trim();
       logs = (
         await exec(
           `git log ${tag}..HEAD --pretty=format:'%s%n%b${HASH_SEPARATOR}%h${SEPARATOR}' --abbrev-commit`


### PR DESCRIPTION
Without matching the tag prefix, you can (and I did) end up in a case where it can't find a suitable ref to bump